### PR TITLE
Added Header Check middleware and Basic Exception Handling

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -83,9 +83,9 @@ $app->singleton(
 |
 */
 
-// $app->middleware([
-//    App\Http\Middleware\ExampleMiddleware::class
-// ]);
+ $app->middleware([
+    \Luminary\Services\ApiRequest\Middleware\RequestHeaders::class
+ ]);
 
 // $app->routeMiddleware([
 //     'auth' => App\Http\Middleware\Authenticate::class,
@@ -102,7 +102,7 @@ $app->singleton(
 |
 */
 
-$app->register(Luminary\Providers\LuminaryServiceProvider::class);
+ $app->register(Luminary\Providers\LuminaryServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------
@@ -114,20 +114,20 @@ $app->register(Luminary\Providers\LuminaryServiceProvider::class);
 |
 */
 
-$api = $app->loadApi([
+ $api = $app->loadApi([
     \Luminary\Services\ApiLoader\Loaders\EntityLoader::class,
     \Luminary\Services\ApiLoader\Loaders\ResourceLoader::class,
     \Luminary\Services\ApiLoader\Loaders\ServiceLoader::class
-]);
+ ]);
 
-$api->registerConsole();
-$api->registerModelFactories();
-$api->registerMiddleware();
-$api->registerMigrations();
-$api->registerProviders();
-$api->registerRoutes();
-$api->registerRouteMiddleware();
-$api->registerSeeders();
+ $api->registerConsole();
+ $api->registerModelFactories();
+ $api->registerMiddleware();
+ $api->registerMigrations();
+ $api->registerProviders();
+ $api->registerRoutes();
+ $api->registerRouteMiddleware();
+ $api->registerSeeders();
 
 /*
 |--------------------------------------------------------------------------
@@ -140,4 +140,4 @@ $api->registerSeeders();
 |
 */
 
-return $app;
+ return $app;

--- a/luminary/Exceptions/Presenters/AbstractPresenter.php
+++ b/luminary/Exceptions/Presenters/AbstractPresenter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Luminary\Exceptions\Presenters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+abstract class AbstractPresenter implements PresenterInterface
+{
+    /**
+     * The Exception instance
+     *
+     * @var Exception
+     */
+    protected $exception;
+
+    /**
+     * DefaultPresenter constructor.
+     *
+     * @param Exception $exception
+     */
+    public function __construct(Exception $exception)
+    {
+        $this->exception = $exception;
+    }
+
+    /**
+     * Return the error message
+     *
+     * @return string
+     */
+    public function message() :string
+    {
+        return $this->exception->getMessage();
+    }
+
+    /**
+     * Render the json response
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function render() :JsonResponse
+    {
+        $headers = [
+            'Content-Type' => 'application/vnd.api+json'
+        ];
+
+        return response()->json(['errors' => $this->response()], $this->status(), $headers);
+    }
+
+    /**
+     * Return the error response array
+     *
+     * @return array
+     */
+    abstract public function response() :array;
+
+    /**
+     * Return the http status code
+     *
+     * @return int
+     */
+    public function status() :int
+    {
+        return (int) $this->exception->getCode();
+    }
+
+    /**
+     * Return the error response title
+     *
+     * @return string
+     */
+    public function title() :string
+    {
+        return 'An unknown error has occurred';
+    }
+}

--- a/luminary/Exceptions/Presenters/DefaultPresenter.php
+++ b/luminary/Exceptions/Presenters/DefaultPresenter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Luminary\Exceptions\Presenters;
+
+class DefaultPresenter extends AbstractPresenter
+{
+    /**
+     * Return the error response array
+     *
+     * @return array
+     */
+    public function response() :array
+    {
+        return [
+            [
+                'status' => $this->status(),
+                'title' => $this->title(),
+                'detail' => $this->message()
+            ]
+        ];
+    }
+}

--- a/luminary/Exceptions/Presenters/HttpExceptionPresenter.php
+++ b/luminary/Exceptions/Presenters/HttpExceptionPresenter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Luminary\Exceptions\Presenters;
+
+class HttpExceptionPresenter extends DefaultPresenter
+{
+    /**
+     * The Exception instance
+     *
+     * @var \Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    protected $exception;
+
+    /**
+     * Return the http status code
+     *
+     * @return int
+     */
+    public function status() :int
+    {
+        return (int) $this->exception->getStatusCode();
+    }
+
+    /**
+     * Return the error response title
+     *
+     * @return string
+     */
+    public function title() :string
+    {
+        return 'An internal server error has occurred';
+    }
+}

--- a/luminary/Exceptions/Presenters/PresenterInterface.php
+++ b/luminary/Exceptions/Presenters/PresenterInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Luminary\Exceptions\Presenters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+interface PresenterInterface
+{
+    /**
+     * DefaultPresenter constructor.
+     *
+     * @param Exception $exception
+     */
+    public function __construct(Exception $exception);
+
+    /**
+     * Return the error message
+     *
+     * @return string
+     */
+    public function message() :string;
+
+    /**
+     * Render the json response
+     * @return JsonResponse
+     */
+    public function render() :JsonResponse;
+
+    /**
+     * Return the error response array
+     *
+     * @return array
+     */
+    public function response() :array;
+
+    /**
+     * Return the http status code
+     *
+     * @return int
+     */
+    public function status() :int;
+
+    /**
+     * Return the error response title
+     *
+     * @return string
+     */
+    public function title() :string;
+}

--- a/luminary/Services/ApiRequest/Exceptions/MediaTypeParametersNotAllowed.php
+++ b/luminary/Services/ApiRequest/Exceptions/MediaTypeParametersNotAllowed.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Luminary\Services\ApiRequest\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MediaTypeParametersNotAllowed extends HttpException
+{
+    /**
+     * The header where
+     * the incorrect type was detected
+     *
+     * @var string
+     */
+    public $headerName;
+
+    /**
+     * UnsupportedMediaTypeException constructor
+     *
+     * @param string $headerName
+     * @param null $message
+     * @param \Exception|null $previous
+     * @param int $code
+     */
+    public function __construct(string $headerName, $message = null, \Exception $previous = null, $code = 406)
+    {
+        parent::__construct(406, $message, $previous, array(), $code);
+    }
+
+    /**
+     * Get the type property
+     *
+     * @return string
+     */
+    public function getHeaderName()
+    {
+        return $this->headerName;
+    }
+}

--- a/luminary/Services/ApiRequest/Exceptions/Presenters/UnsupportedMediaTypePresenter.php
+++ b/luminary/Services/ApiRequest/Exceptions/Presenters/UnsupportedMediaTypePresenter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Luminary\Services\ApiRequest\Exceptions\Presenters;
+
+use Luminary\Exceptions\Presenters\HttpExceptionPresenter;
+
+class UnsupportedMediaTypePresenter extends HttpExceptionPresenter
+{
+    /**
+     * Return the error response title
+     *
+     * @return string
+     */
+    public function title() :string
+    {
+        return 'An unsupported Media Type was detected';
+    }
+
+    /**
+     * Return the error response array
+     *
+     * @return array
+     */
+    public function response() :array
+    {
+        return [
+            [
+                'status' => $this->status(),
+                'title' => $this->title(),
+                'detail' => $this->message()
+            ]
+        ];
+    }
+}

--- a/luminary/Services/ApiRequest/Exceptions/UnsupportedMediaType.php
+++ b/luminary/Services/ApiRequest/Exceptions/UnsupportedMediaType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Luminary\Services\ApiRequest\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class UnsupportedMediaType extends HttpException
+{
+    /**
+     * The header where
+     * the incorrect type was detected
+     *
+     * @var string
+     */
+    public $headerName;
+
+    /**
+     * UnsupportedMediaTypeException constructor
+     *
+     * @param string $headerName
+     * @param null $message
+     * @param \Exception|null $previous
+     * @param int $code
+     */
+    public function __construct(string $headerName, $message = null, \Exception $previous = null, $code = 415)
+    {
+        parent::__construct(415, $message, $previous, array(), $code);
+    }
+
+    /**
+     * Get the type property
+     *
+     * @return string
+     */
+    public function getHeaderName()
+    {
+        return $this->headerName;
+    }
+}

--- a/luminary/Services/ApiRequest/Middleware/RequestHeaders.php
+++ b/luminary/Services/ApiRequest/Middleware/RequestHeaders.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Luminary\Services\ApiRequest\Middleware;
+
+use Closure;
+use Luminary\Services\ApiRequest\Exceptions\MediaTypeParametersNotAllowed;
+use Luminary\Services\ApiRequest\Exceptions\UnsupportedMediaType;
+
+class RequestHeaders
+{
+    /**
+     * The vendor tree string
+     *
+     * @var string
+     */
+    protected $vendorTree = 'application/vnd';
+
+    /**
+     * The producer string
+     *
+     * @var string
+     */
+    protected $producer = 'api';
+
+    /**
+     * The request media type
+     *
+     * @var string
+     */
+    protected $mediaType = 'json';
+
+    /**
+     * Get the accepted vendor tree property
+     *
+     * @return string
+     */
+    public function vendorTree()
+    {
+        return $this->vendorTree;
+    }
+
+    /**
+     * Get the accepted producer property
+     *
+     * @return string
+     */
+    public function producer()
+    {
+        return $this->producer;
+    }
+
+    /**
+     * Get the accepted media type property
+     *
+     * @return string
+     */
+    public function mediaType()
+    {
+        return $this->mediaType;
+    }
+
+    /**
+     * Return the fully concatenated
+     * acceptable media type
+     *
+     * @return string
+     */
+    public function acceptedHeader() :string
+    {
+        return $this->vendorTree() . '.' . $this->producer() . '+' . $this->mediaType();
+    }
+
+    /**
+     * Run the request filter.
+     *
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $accept = $request->header('accept');
+        $content = $request->header('content-type');
+
+
+        $this->handleContentType($content);
+        $this->handleAcceptHeaders($accept);
+
+        return $next($request);
+    }
+
+    /**
+     * Validate the content-type header
+     *
+     * @param $contentType
+     */
+    protected function handleContentType($contentType) :void
+    {
+        if ($this->isStrictMatch($contentType)) {
+            return;
+        }
+
+        $this->handleHeader($contentType, 'Content-Type');
+    }
+
+    /**
+     * Validate the accept headers
+     *
+     * @param string $header
+     * @return void
+     */
+    protected function handleAcceptHeaders(string $header) :void
+    {
+        collect(explode(',', $header))->each(
+            function ($accept) {
+                if ($this->isVendor($accept)) {
+                    $this->handleHeader($accept, 'Accept');
+                }
+            }
+        );
+    }
+
+    /**
+     * Handle an individual header validation
+     *
+     * @param $header
+     * @param $type
+     */
+    protected function handleHeader($header, $type) :void
+    {
+        if (! $this->isCorrectVendor($header) || ! $this->hasCorrectMediaType($header)) {
+            $this->throwUnsupportedMediaTypeException($type);
+        } elseif ($this->hasAdditionalParameters($header)) {
+            $this->throwMediaTypeParametersNotAllowException($type);
+        }
+    }
+
+    /**
+     * Check if the header is a strict
+     * match to the accepted header
+     *
+     * @param string $header
+     * @return bool
+     */
+    public function isStrictMatch(string $header) :bool
+    {
+        return $header === $this->acceptedHeader();
+    }
+
+    /**
+     * Does the header have vendor name
+     *
+     * @param string $header
+     * @return bool
+     */
+    public function isVendor(string $header) :bool
+    {
+        preg_match('#' . $this->vendorTree() . '\.' . $this->producer() . '#', $header, $matches);
+
+        return (count($matches));
+    }
+
+    /**
+     * Does the header have the correct vendor
+     *
+     * @param string $header
+     * @return bool
+     */
+    public function isCorrectVendor(string $header) :bool
+    {
+        return $this->isVendor($header);
+    }
+
+    /**
+     * Does the header have the correct media type?
+     *
+     * @param string $header
+     * @return bool
+     */
+    public function hasCorrectMediaType(string $header) :bool
+    {
+        preg_match('#' . $this->vendorTree() . '\.' . $this->producer() . '\+(\w+)#', $header, $matches);
+
+        $matches = array_slice($matches, 1);
+
+        return count($matches) && head($matches) === 'json';
+    }
+
+    /**
+     * Does the header have additional parameters?
+     *
+     * @param string $header
+     * @return bool
+     */
+    public function hasAdditionalParameters(string $header) :bool
+    {
+        $pattern = preg_quote($this->acceptedHeader(), '/');
+
+        preg_match('/' . $pattern . '/', $header, $matches);
+
+        $count = count($matches);
+
+        if ($count) {
+            $count = collect(explode(';', $header))->filter(function ($item) {
+                return trim($item);
+            })->slice(1)->count();
+        }
+
+        return (bool) $count;
+    }
+
+    /**
+     * Throw a new unsupported media type exception
+     *
+     * @param string $type
+     * @throws \Luminary\Services\ApiRequest\Exceptions\UnsupportedMediaType
+     */
+    public function throwUnsupportedMediaTypeException(string $type)
+    {
+        $message = 'The media type for ' . $type . ' must be: ' . $this->acceptedHeader();
+        throw new UnsupportedMediaType($type, $message);
+    }
+
+    /**
+     * Throw a new media type parameters not allow exception
+     *
+     * @param string $type
+     * @throws \Luminary\Services\ApiRequest\Exceptions\MediaTypeParametersNotAllowed
+     */
+    public function throwMediaTypeParametersNotAllowException(string $type)
+    {
+        $message = 'Media type parameters are not allowed. Only ';
+        $message .= $this->acceptedHeader() . ' is allowed for ' . $type . 'Header.';
+
+        throw new MediaTypeParametersNotAllowed($type, $message);
+    }
+}

--- a/tests/ApiQuery/QueryMiddlewareTest.php
+++ b/tests/ApiQuery/QueryMiddlewareTest.php
@@ -35,7 +35,7 @@ class QueryMiddlewareTest extends TestCase
      */
     public function testQueryMiddlewareWillBeTriggeredOnGetRequest()
     {
-        $this->get($this->url);
+        $this->get($this->url, ['content-type' => 'application/vnd.api+json']);
 
         $this->assertCount(1, $this->getQueryArray());
         $this->assertResponseOk();
@@ -49,7 +49,7 @@ class QueryMiddlewareTest extends TestCase
      */
     public function testQueryMiddlewareWillNotBeTriggeredOnPostRequest()
     {
-        $this->post($this->url);
+        $this->post($this->url, [], ['content-type' => 'application/vnd.api+json']);
         $response = $this->response;
 
         $this->assertCount(0, $this->getQueryArray());
@@ -64,7 +64,7 @@ class QueryMiddlewareTest extends TestCase
      */
     public function testQueryMiddlewareWillNotBeTriggeredOnPutRequest()
     {
-        $this->put($this->url);
+        $this->put($this->url, [], ['content-type' => 'application/vnd.api+json']);
         $response = $this->response;
 
         $this->assertCount(0, $this->getQueryArray());
@@ -79,7 +79,7 @@ class QueryMiddlewareTest extends TestCase
      */
     public function testQueryMiddlewareWillNotBeTriggeredOnPatchRequest()
     {
-        $this->patch($this->url);
+        $this->patch($this->url, [], ['content-type' => 'application/vnd.api+json']);
         $response = $this->response;
 
         $this->assertCount(0, $this->getQueryArray());
@@ -94,7 +94,7 @@ class QueryMiddlewareTest extends TestCase
      */
     public function testQueryMiddlewareWillNotBeTriggeredOnDeleteRequest()
     {
-        $this->delete($this->url);
+        $this->delete($this->url, [], ['content-type' => 'application/vnd.api+json']);
         $response = $this->response;
 
         $this->assertCount(0, $this->getQueryArray());

--- a/tests/ApiRequest/JsonApiRequestMiddlewareTest.php
+++ b/tests/ApiRequest/JsonApiRequestMiddlewareTest.php
@@ -1,0 +1,242 @@
+<?php
+
+use Illuminate\Http\Request;
+use Luminary\Services\ApiRequest\Exceptions\MediaTypeParametersNotAllowed;
+use Luminary\Services\ApiRequest\Exceptions\UnsupportedMediaType;
+use Luminary\Services\ApiRequest\Middleware\RequestHeaders;
+
+class JsonApiRequestMiddlewareTest extends TestCase
+{
+    /**
+     * The JsonApiRequest instance
+     *
+     * @var \Luminary\Services\ApiRequest\Middleware\RequestHeaders
+     */
+    protected $middleware;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->middleware = new RequestHeaders;
+        $this->app->instance('middleware.disable', true);
+    }
+
+    /**
+     * Check that header matches exactly
+     *
+     * @return void
+     */
+    public function testIsStrictMethod() :void
+    {
+        $middleware = $this->middleware;
+
+        $this->assertTrue($middleware->isStrictMatch('application/vnd.api+json'));
+        $this->assertFalse($middleware->isStrictMatch('application/vnd.api'));
+    }
+
+    /**
+     * Check that the vendor tree and producer
+     * supplied is correct
+     *
+     * @return void
+     */
+    public function testCheckVendorMethod() :void
+    {
+        $middleware = $this->middleware;
+
+        $this->assertTrue($middleware->isCorrectVendor('application/vnd.api+json'));
+        $this->assertFalse($middleware->isCorrectVendor('application/vnd.test'));
+    }
+
+    /**
+     * Check that the media type supplied is correct
+     *
+     * @return void
+     */
+    public function testCheckMediaTypeMethod() :void
+    {
+        $middleware = $this->middleware;
+
+        $this->assertTrue($middleware->hasCorrectMediaType('application/vnd.api+json'));
+        $this->assertFalse($middleware->hasCorrectMediaType('application/vnd.api+xml'));
+    }
+
+    /**
+     * Check that a api header does not include
+     * any additional parameters
+     *
+     * @return void
+     */
+    public function testCheckParameters() :void
+    {
+        $middleware = $this->middleware;
+
+        $this->assertFalse($middleware->hasAdditionalParameters('application/vnd.api+json;'));
+        $this->assertFalse($middleware->hasAdditionalParameters('application/vnd.vendor+xml; charset=utf-8'));
+        $this->assertTrue($middleware->hasAdditionalParameters('application/vnd.api+json; charset=utf-8'));
+    }
+
+    /**
+     * Test that strict checking for content type passes
+     *
+     * @return void
+     */
+    public function testStrictContentTypePasses()
+    {
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/vnd.api+json');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+
+        $this->assertSame('success', $response->getContent());
+    }
+
+    /**
+     * Test that the media type check fails
+     * for content-type check
+     *
+     * @return void
+     */
+    public function testContentTypeIncorrectMediaTypeFails()
+    {
+        $this->expectException(UnsupportedMediaType::class);
+        $this->expectExceptionCode(415);
+
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+        $response->getContent();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/wrong.api+json');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+    }
+
+    /**
+     * Test that the additional media type parameters
+     * check fails for content-type check
+     *
+     * @return void
+     */
+    public function testContentTypeMediaTypeParametersFail()
+    {
+        $this->expectException(MediaTypeParametersNotAllowed::class);
+        $this->expectExceptionCode(406);
+
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+        $response->getContent();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/vnd.api+json; charset=utf-8');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+    }
+
+    /**
+     * Test that strict checking for accept headers pass
+     *
+     * @return void
+     */
+    public function testStrictAcceptPasses()
+    {
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/vnd.api+json');
+        $request->headers->set('accept', 'application/vnd.api+json');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+
+        $this->assertSame('success', $response->getContent());
+    }
+
+    /**
+     * Test that the media type check fails
+     * for accept headers
+     *
+     * @return void
+     */
+    public function testAcceptIncorrectMediaTypeFails()
+    {
+        $this->expectException(UnsupportedMediaType::class);
+        $this->expectExceptionCode(415);
+
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+        $response->getContent();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/api.api+json');
+        $request->headers->set('accept', 'application/vnd.wrong+json');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+    }
+
+    /**
+     * Test that the additional media type parameters
+     * check fails for accept headers
+     *
+     * @return void
+     */
+    public function testAcceptMediaTypeParametersFail()
+    {
+        $this->expectException(MediaTypeParametersNotAllowed::class);
+        $this->expectExceptionCode(406);
+
+        // Create the response
+        $response = Mockery::mock('Illuminate\Http\Response')->shouldReceive('getContent')->once()->andReturn('success')->getMock();
+        $response->getContent();
+
+        // Create the request
+        $request = Request::create('http://example.com/api', 'GET');
+        $request->headers->set('content-type', 'application/vnd.api+json');
+        $request->headers->set('accept', 'application/vnd.api+json; charset=utf-8');
+
+        // Pass it to the middleware
+        $this->middleware->handle($request,
+            function () use ($response) {
+                return $response;
+            }
+        );
+    }
+}

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -12,6 +12,10 @@ class ExampleTest extends TestCase
      */
     public function testExample()
     {
-        //
+//        $this->get('/', ['content-type' => 'application/vnd.api+json']);
+//
+//        $this->assertEquals(
+//            $this->app->version(), $this->response->getContent()
+//        );
     }
 }

--- a/tests/Exceptions/ExceptionDefaultPresenterTest.php
+++ b/tests/Exceptions/ExceptionDefaultPresenterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Luminary\Exceptions\Presenters\DefaultPresenter;
+
+class ExceptionDefaultPresenterTest extends TestCase
+{
+    /**
+     * Check that the default presenter returns
+     * correct data
+     *
+     * @return void
+     */
+    public function testDefaultPresenter() :void
+    {
+        $e = new Exception('this is a default exception', 404);
+        $response = (new DefaultPresenter($e))->response();
+        $expected = [[
+            'status' => 404,
+            'title' => 'An unknown error has occurred',
+            'detail' => 'this is a default exception'
+        ]];
+
+        $this->assertEquals($expected, $response);
+    }
+}

--- a/tests/Exceptions/ExceptionResponseHandlerTest.php
+++ b/tests/Exceptions/ExceptionResponseHandlerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Http\Request;
+use Luminary\Exceptions\Handler;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ExceptionResponseHandlerTest extends TestCase
+{
+    /**
+     * Check that the application exception handler
+     * returns the correct response
+     *
+     * @return void
+     */
+    public function testServerError() :void
+    {
+        $request = Request::create('http://example.com/api', 'GET');
+        $handler = new Handler;
+        $exception = new HttpException(500);
+        $expected = [
+            'errors' => [
+                [
+                    'status' => 500,
+                    'title' => 'An internal server error has occurred',
+                    'detail' => ''
+                ]
+            ]
+        ];
+
+        $this->response = app()->prepareResponse(
+            $handler->render($request, $exception)
+        );
+
+        $this->seeJson($expected);
+    }
+}

--- a/tests/Exceptions/HttpExceptionPresenterTest.php
+++ b/tests/Exceptions/HttpExceptionPresenterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Luminary\Exceptions\Presenters\HttpExceptionPresenter;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class HttpExceptionPresenterTest extends TestCase
+{
+    /**
+     * Check that the http exception presenter
+     * returns the correct data
+     *
+     * @return void
+     */
+    public function testHttpExceptionPresenter() :void
+    {
+        $e = new HttpException(500);
+        $response = (new HttpExceptionPresenter($e))->response();
+        $expected = [[
+            'status' => 500,
+            'title' => 'An internal server error has occurred',
+            'detail' => ''
+        ]];
+
+        $this->assertEquals($expected, $response);
+    }
+}


### PR DESCRIPTION
This Adds header checks requiring Content-Type, and expecting a specific entry for the JSON API spec headers.

This also includes basic implementation for Exception handling responses to format based on the JSON API spec.

This covers ENGFDTN-55: [content negotiation requirements](http://jsonapi.org/format/#content-negotiation) , and ENGFDTN-56: [basic error response formatting](http://jsonapi.org/format/#errors)