### PR TITLE
Pagination Response Fixes

### DIFF
--- a/luminary/Services/ApiQuery/Pagination/Paginators/LengthAwarePaginator.php
+++ b/luminary/Services/ApiQuery/Pagination/Paginators/LengthAwarePaginator.php
@@ -86,7 +86,7 @@ class LengthAwarePaginator extends IlluminateLengthAwarePaginator
     public function createUrlParameters(int $page, int $perPage) :array
     {
         return [
-            'paginate' => [
+            'page' => [
                 'number' => $page,
                 'size' => $perPage
             ]

--- a/luminary/Services/ApiResponse/Serializers/AbstractSerializer.php
+++ b/luminary/Services/ApiResponse/Serializers/AbstractSerializer.php
@@ -268,9 +268,19 @@ abstract class AbstractSerializer implements SerializerInterface
      */
     public function setPaginatedMeta() :AbstractSerializer
     {
+        $baseUrl = $this->selfLink();
+
         if ($this->paginated()) {
             $paginator = $this->paginator();
-            $this->addMeta('pagination', $paginator->toArray());
+            $meta = collect($paginator->toArray())->map(function($item, $key) use($baseUrl) {
+                 if(preg_match('/_url/i', $key)) {
+                     return $baseUrl . $item;
+                 }
+
+                 return $item;
+            })->toArray();
+
+            $this->addMeta('pagination', $meta);
         }
 
         return $this;
@@ -296,7 +306,7 @@ abstract class AbstractSerializer implements SerializerInterface
 
         return collect($urls)->map(
             function ($query) use ($baseUrl) {
-                return $baseUrl . $query;
+                return $query ? $baseUrl . $query : null;
             }
         )->all();
     }


### PR DESCRIPTION
- Fixed prev link for first page to show null instead of just the base url
- Fixed next link for lasst page to show null instead of just the base url
- Fixed pagination meta to have full urls
- Fixed generated urls to use page instead of paginate for query string params