### PR TITLE
Fixed generator naming for entities and resources w/multiple words

### DIFF
--- a/luminary/Database/Eloquent/Model.php
+++ b/luminary/Database/Eloquent/Model.php
@@ -12,4 +12,30 @@ class Model extends EloquentModel
     use QueryTrait;
     use ResponseModelTrait;
     use TimezoneModelTrait;
+
+    public function resource()
+    {
+        //return $this->typ
+    }
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value)
+    {
+        // @todo: find out the implementation for laravel 5.5
+    }
+
+    /**
+     * Get the connection of the entity.
+     *
+     * @return string|null
+     */
+    public function getQueueableConnection()
+    {
+        // @todo: find out the implementation for laravel 5.5
+    }
 }

--- a/luminary/Services/ApiRequest/ApiRequest.php
+++ b/luminary/Services/ApiRequest/ApiRequest.php
@@ -143,6 +143,7 @@ class ApiRequest extends Request
      */
     public function setType(string $type) :ApiRequest
     {
+        $type = str_replace('-', '_', $type);
         $this->type = $type;
 
         return $this;
@@ -176,6 +177,7 @@ class ApiRequest extends Request
      */
     public function setResource(string $resource) :ApiRequest
     {
+        $resource = str_replace('_', '-', $resource);
         $this->resource = $resource;
 
         return $this;

--- a/luminary/Services/ApiRequest/Middleware/RequestRouteMiddleware.php
+++ b/luminary/Services/ApiRequest/Middleware/RequestRouteMiddleware.php
@@ -56,6 +56,9 @@ class RequestRouteMiddleware
         $method = $request->method();
 
         switch ($method) {
+            case 'GET':
+                $this->handleGet($request);
+                break;
             case 'POST':
                 $this->handlePost($request);
                 break;
@@ -106,13 +109,25 @@ class RequestRouteMiddleware
             return;
         }
 
-        (new DeleteRelationship)->validate($request);
+        with(new DeleteRelationship)->validate($request);
 
         $content = $this->content($request);
 
         $request->setType($content->type());
         $request->setData($content->attributes());
         $request->setRelationships($content->relationships());
+    }
+
+    /**
+    * Handle a GET Request
+    *
+    * @param ApiRequest $request
+    * @return void
+    */
+    protected function handleGet(ApiRequest $request)
+    {
+        $resource = $request->segment(1) ?: '';
+        $request->setType($resource);
     }
 
     /**
@@ -182,6 +197,6 @@ class RequestRouteMiddleware
             $resource = $this->request->segment(1) ?: '';
         }
 
-        $this->request->setResource(str_plural($resource));
+        $this->request->setResource($resource);
     }
 }

--- a/luminary/Services/ApiResponse/ResponseHelper.php
+++ b/luminary/Services/ApiResponse/ResponseHelper.php
@@ -74,7 +74,19 @@ class ResponseHelper
     public static function resourceSelf($resourceId = null, string $resource = null) :string
     {
         $resource = $resource ?: static::resource();
+        $resource = static::formatResource($resource);
         return static::generateUrl([$resource, $resourceId]);
+    }
+
+    /**
+     * Format a resource name with dashes
+     *
+     * @param string $resource
+     * @return string
+     */
+    public static function formatResource(string $resource) :string
+    {
+        return str_replace(['_', ' '], '-', $resource);
     }
 
     /**
@@ -92,6 +104,8 @@ class ResponseHelper
         string $relationship,
         bool $plural = true
     ) :array {
+        $resource = static::formatResource($resource);
+        $relationship = static::formatResource($relationship);
         $relationship = $plural ? str_plural($relationship) : str_singular($relationship);
 
         return [
@@ -109,7 +123,12 @@ class ResponseHelper
      */
     public static function generateUrl(array $path)
     {
+        $path = array_map(function ($segment) {
+            return static::formatResource($segment ?: '');
+        }, $path);
+
         $path = array_merge([static::root()], [config('luminary.location')], $path);
+
         return implode('/', array_filter($path));
     }
 

--- a/luminary/Services/Generators/Creators/Database/Migration.php
+++ b/luminary/Services/Generators/Creators/Database/Migration.php
@@ -4,7 +4,6 @@ namespace Luminary\Services\Generators\Creators\Database;
 
 use Illuminate\Filesystem\Filesystem;
 use Luminary\Services\Generators\Contracts\CreatorInterface;
-use Illuminate\Database\Migrations\MigrationCreator;
 
 class Migration implements CreatorInterface
 {

--- a/luminary/Services/Generators/Creators/Database/stubs/create.stub
+++ b/luminary/Services/Generators/Creators/Database/stubs/create.stub
@@ -7,17 +7,20 @@ use Illuminate\Database\Migrations\Migration;
 class DummyClass extends Migration
 {
     /**
+     * The table name
+     *
+     * @var string
+     */
+    protected $table = 'DummyTable';
+
+    /**
      * Run the migrations.
      *
      * @return void
      */
     public function up()
     {
-        Schema::create('DummyTable', function (Blueprint $table) {
-            $table->increments('id');
-            $table->timestamps();
-            $table->softDeletes();
-        });
+        $this->createTable();
     }
 
     /**
@@ -27,6 +30,37 @@ class DummyClass extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('DummyTable');
+        $this->dropForeignKeys();
+        Schema::dropIfExists($this->table);
+    }
+
+    /**
+     * Create the people table
+     *
+     * @return void
+     */
+    public function createTable() :void
+    {
+        Schema::create('DummyTable', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->primary('id');
+            $table->index(['created_at', 'updated_at', 'deleted_at']);
+            //$table->foreign('tablenameSingular_id')->references('id')->on('tablename');
+        });
+    }
+
+    /**
+     * Drop the tables foreign keys
+     *
+     * @return void
+     */
+    protected function dropForeignKeys() :void
+    {
+        Schema::table($this->table, function($table) {
+            //$table->dropForeign($this->table . '_tablenameSingular_id_foreign');
+        });
     }
 }

--- a/luminary/Services/Generators/Creators/Routes/Routes.php
+++ b/luminary/Services/Generators/Creators/Routes/Routes.php
@@ -16,7 +16,8 @@ class Routes extends StubCreator
         'relatedController' => '',
         'relationshipController' => '',
         'namespace' => '',
-        'slug' => ''
+        'slug' => '',
+        'routeName' => ''
     ];
 
     /**

--- a/luminary/Services/Generators/Creators/Routes/stubs/routes.stub
+++ b/luminary/Services/Generators/Creators/Routes/stubs/routes.stub
@@ -15,31 +15,31 @@ $router->group(['namespace' => '{{namespace}}', 'prefix' => '{{slug}}'],
     function ($router) {
         // Retrieve a list for {{slug}}
         $router->get('/', [
-            'as' => '{{slug}}',
+            'as' => '{{routeName}}',
             'uses' => '{{controller}}@index'
         ]);
 
         // Create a new entity for {{slug}}
         $router->post('/', [
-            'as' => '{{slug}}.store',
+            'as' => '{{routeName}}.store',
             'uses' => '{{controller}}@store'
         ]);
 
         // Show an entity for {{slug}}
         $router->get('/{id}', [
-            'as' => '{{slug}}.show',
+            'as' => '{{routeName}}.show',
             'uses' => '{{controller}}@show'
         ]);
 
         // Update an entity for {{slug}}
         $router->patch('/{id}', [
-            'as' => '{{slug}}.update',
+            'as' => '{{routeName}}.update',
             'uses' => '{{controller}}@update'
         ]);
 
         // Delte an entity for {{slug}}
         $router->delete('/{id}', [
-            'as' => '{{slug}}.destroy',
+            'as' => '{{routeName}}.destroy',
             'uses' => '{{controller}}@destroy'
         ]);
     }
@@ -50,25 +50,25 @@ $router->group(['namespace' => '{{namespace}}', 'prefix' => '{{slug}}/{id}'],
     function ($router) {
         // Retrieve a {{slug}} relationship
         $router->get('/relationships/{relationship}', [
-            'as' => '{{slug}}.relationships',
+            'as' => '{{routeName}}.relationships',
             'uses' => '{{relationshipController}}@index'
         ]);
 
         // Update a {{slug}} relationship
         $router->post('/relationships/{relationship}', [
-            'as' => '{{slug}}.relationships.create',
+            'as' => '{{routeName}}.relationships.create',
             'uses' => '{{relationshipController}}@store'
         ]);
 
         // Update a {{slug}} relationship
         $router->patch('/relationships/{relationship}', [
-            'as' => '{{slug}}.relationships.update',
+            'as' => '{{routeName}}.relationships.update',
             'uses' => '{{relationshipController}}@update'
         ]);
 
         // Delete a {{slug}} relationship
         $router->delete('/relationships/{relationship}', [
-            'as' => '{{slug}}.relationships.delete',
+            'as' => '{{routeName}}.relationships.delete',
             'uses' => '{{relationshipController}}@destroy'
         ]);
     }
@@ -79,31 +79,31 @@ $router->group(['namespace' => '{{namespace}}', 'prefix' => '{{slug}}/{id}'],
     function ($router) {
         // Retrieve a {{slug}} relationship
         $router->get('/{related}', [
-            'as' => '{{slug}}.related',
+            'as' => '{{routeName}}.related',
             'uses' => '{{relatedController}}@index'
         ]);
 
         // Retrieve the customer relationship record
         $router->get('/{related}/{relatedId}', [
-            'as' => '{{slug}}.related.show',
+            'as' => '{{routeName}}.related.show',
             'uses' => '{{relatedController}}@show'
         ]);
 
         // Update a {{slug}} relationship
         $router->post('/{related}', [
-            'as' => '{{slug}}.related.create',
+            'as' => '{{routeName}}.related.create',
             'uses' => '{{relatedController}}@store'
         ]);
 
         // Update a {{slug}} relationship
         $router->patch('/{related}/{relatedId}', [
-            'as' => '{{slug}}.related.update',
+            'as' => '{{routeName}}.related.update',
             'uses' => '{{relatedController}}@update'
         ]);
 
         // Delete a {{slug}} relationship
         $router->delete('/{related}/{relatedId}', [
-            'as' => '{{slug}}.related.delete',
+            'as' => '{{routeName}}.related.delete',
             'uses' => '{{relatedController}}@destroy'
         ]);
     }

--- a/luminary/Services/Generators/Entity/Scaffold.php
+++ b/luminary/Services/Generators/Entity/Scaffold.php
@@ -48,7 +48,7 @@ class Scaffold implements CreatorInterface
      */
     protected static function database(string $name, string $path) :void
     {
-        $lname = strtolower($name);
+        $lname = strtolower(snake_case($name));
         $singular = str_singular($name);
 
         // DB

--- a/luminary/Services/Generators/Resource/Scaffold.php
+++ b/luminary/Services/Generators/Resource/Scaffold.php
@@ -61,11 +61,9 @@ class Scaffold implements CreatorInterface
      */
     protected static function request(string $name, string $path) :void
     {
-        $name = studly_case(str_singular($name));
         $requestsPath = $path.'/Requests';
 
         RequestStructure::create($path);
-        ValidatorStructure::create($path);
         Validator::create('Store', $requestsPath . '/Validators');
         Validator::create('Update', $requestsPath . '/Validators');
         Authorizer::create('Auth', $requestsPath);
@@ -116,8 +114,9 @@ class Scaffold implements CreatorInterface
      */
     protected static function route(string $name, string $path) :void
     {
-        $name = studly_case(str_singular($name));
         $slug = str_slug(str_plural($name));
+        $routeName = snake_case(str_replace(['-', ' '], '.', $name));
+        $name = studly_case(str_singular($name));
         $relative_path = str_replace(app_path().'/', 'Api/', $path);
         $namespace = str_replace('/', '\\', $relative_path.'/Controllers');
 
@@ -126,7 +125,8 @@ class Scaffold implements CreatorInterface
             'relatedController' => $name.'RelatedController',
             'relationshipController' => $name.'RelationshipController',
             'namespace' => $namespace,
-            'slug' => $slug
+            'slug' => $slug,
+            'routeName' => $routeName
         ]);
     }
 

--- a/tests/ApiRequest/ApiRequestResourceTest.php
+++ b/tests/ApiRequest/ApiRequestResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Http\Request;
+
+class ApiRequestResourceTest extends TestCase
+{
+    /**
+     * Required request headers
+     *
+     * @var array
+     */
+    protected $headers = ['CONTENT_TYPE' => 'application/vnd.api+json'];
+
+    /**
+     * Test data attribute failure
+     *
+     * @return void
+     */
+    public function testTypeAndResource() :void
+    {
+        $phpunit = $this;
+        $router = app()->router;
+
+        $router->group(['middleware' => 'request'], function($router) use($phpunit) {
+            $router->get('multi-word-resource', function(Request $request) use($phpunit) {
+                $phpunit->assertEquals('multi_word_resource', $request->type());
+                $phpunit->assertEquals('multi-word-resource', $request->resource());
+            });
+        });
+
+        $this->get('multi-word-resource', $this->headers);
+    }
+}


### PR DESCRIPTION
- Fixed migration file names and table names to be underscored
- Fixed model table name to be underscored
- Fixed Resource route prefix to be dashed
- Fixed resource routeNames to use dot notation
- Fixed Validation folder in resource root from being created
- Updated Migration generator to be more flexible
- Updated ApiRequest and RouteMiddleware to set correct type and resource for get requests
- Fixed response urls to have properly formated resource and relationship segments
- Updated Luminary Model class to implement required interface clases from Lumen 5.5